### PR TITLE
Bump engine.io and socket.io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1346,24 +1346,6 @@
         }
       }
     },
-    "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
-      "dev": true,
-      "requires": {
-        "@types/cookie": "^0.4.1",
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.4.1",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
-      }
-    },
     "engine.io-client": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
@@ -5602,24 +5584,53 @@
       }
     },
     "socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.1"
+      },
+      "dependencies": {
+        "engine.io": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+          "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
+          "dev": true,
+          "requires": {
+            "@types/cookie": "^0.4.1",
+            "@types/cors": "^2.8.12",
+            "@types/node": ">=10.0.0",
+            "accepts": "~1.3.4",
+            "base64id": "2.0.0",
+            "cookie": "~0.4.1",
+            "cors": "~2.8.5",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~5.0.3",
+            "ws": "~8.11.0"
+          }
+        },
+        "socket.io-adapter": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+          "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+          "dev": true,
+          "requires": {
+            "ws": "~8.11.0"
+          }
+        },
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "dev": true
+        }
       }
-    },
-    "socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-      "dev": true
     },
     "socket.io-client": {
       "version": "4.5.4",


### PR DESCRIPTION
Bumps [engine.io](https://github.com/socketio/engine.io) and [socket.io](https://github.com/socketio/socket.io). These dependencies needed to be updated together.

Updates `engine.io` from 6.2.1 to 6.4.2
- [Release notes](https://github.com/socketio/engine.io/releases)
- [Changelog](https://github.com/socketio/engine.io/blob/main/CHANGELOG.md)
- [Commits](https://github.com/socketio/engine.io/compare/6.2.1...6.4.2)

Updates `socket.io` from 4.5.4 to 4.6.1
- [Release notes](https://github.com/socketio/socket.io/releases)
- [Changelog](https://github.com/socketio/socket.io/blob/main/CHANGELOG.md)
- [Commits](https://github.com/socketio/socket.io/compare/4.5.4...4.6.1)

---
updated-dependencies:
- dependency-name: engine.io dependency-type: indirect
- dependency-name: socket.io dependency-type: indirect ...